### PR TITLE
Bump the open-source-license group with 8 updates (#23)

### DIFF
--- a/src/iFrame/iFrame.csproj
+++ b/src/iFrame/iFrame.csproj
@@ -10,13 +10,15 @@
 
   <ItemGroup>
     <PackageReference Include="Blazored.LocalStorage" Version="4.5.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.5" PrivateAssets="all" />
-    <PackageReference Include="MudBlazor" Version="8.7.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.8" PrivateAssets="all" />
+  <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="9.0.8" />
+  <PackageReference Include="Microsoft.NET.Sdk.WebAssembly.Pack" Version="9.0.8" />
+    <PackageReference Include="MudBlazor" Version="8.11.0" />
     <PackageReference Include="OneOf" Version="3.0.271" />
-    <PackageReference Include="System.Text.Json" Version="9.0.5" />
-	<PackageReference Include="BlazorWasmPreRendering.Build" Version="5.0.1" />
-	<PackageReference Include="PublishSPAforGitHubPages.Build" Version="3.0.0" />
+    <PackageReference Include="System.Text.Json" Version="9.0.8" />
+	<PackageReference Include="BlazorWasmPreRendering.Build" Version="6.0.0" />
+	<PackageReference Include="PublishSPAforGitHubPages.Build" Version="3.0.1" />
 	<PackageReference Include="ValueOf" Version="2.0.31" />
   </ItemGroup>
 


### PR DESCRIPTION
Bumps BlazorWasmPreRendering.Build from 5.0.1 to 6.0.0 Bumps Microsoft.AspNetCore.Components.WebAssembly from 9.0.5 to 9.0.8 Bumps Microsoft.AspNetCore.Components.WebAssembly.DevServer from 9.0.5 to 9.0.8 Bumps Microsoft.NET.ILLink.Tasks from 9.0.7 to 9.0.8 Bumps Microsoft.NET.Sdk.WebAssembly.Pack from 9.0.7 to 9.0.8 Bumps MudBlazor from 8.7.0 to 8.11.0
Bumps PublishSPAforGitHubPages.Build from 3.0.0 to 3.0.1 Bumps System.Text.Json from 9.0.5 to 9.0.8

---
updated-dependencies:
- dependency-name: BlazorWasmPreRendering.Build dependency-version: 6.0.0 dependency-type: direct:production update-type: version-update:semver-major dependency-group: open-source-license
- dependency-name: Microsoft.AspNetCore.Components.WebAssembly dependency-version: 9.0.8 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: open-source-license
- dependency-name: Microsoft.AspNetCore.Components.WebAssembly.DevServer dependency-version: 9.0.8 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: open-source-license
- dependency-name: Microsoft.NET.ILLink.Tasks dependency-version: 9.0.8 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: open-source-license
- dependency-name: Microsoft.NET.Sdk.WebAssembly.Pack dependency-version: 9.0.8 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: open-source-license
- dependency-name: MudBlazor dependency-version: 8.11.0 dependency-type: direct:production update-type: version-update:semver-minor dependency-group: open-source-license
- dependency-name: PublishSPAforGitHubPages.Build dependency-version: 3.0.1 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: open-source-license
- dependency-name: System.Text.Json dependency-version: 9.0.8 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: open-source-license ...