### PR TITLE
Bump the open-source-license group with 1 update

### DIFF
--- a/src/iFrame/iFrame.csproj
+++ b/src/iFrame/iFrame.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.8" PrivateAssets="all" />
   <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="9.0.8" />
   <PackageReference Include="Microsoft.NET.Sdk.WebAssembly.Pack" Version="9.0.8" />
-    <PackageReference Include="MudBlazor" Version="8.11.0" />
+    <PackageReference Include="MudBlazor" Version="8.12.0" />
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="System.Text.Json" Version="9.0.8" />
 	<PackageReference Include="BlazorWasmPreRendering.Build" Version="6.0.0" />


### PR DESCRIPTION
Bumps MudBlazor from 8.11.0 to 8.12.0

---
updated-dependencies:
- dependency-name: MudBlazor dependency-version: 8.12.0 dependency-type: direct:production update-type: version-update:semver-minor dependency-group: open-source-license ...