### PR TITLE
Bump the open-source-license group with 1 update

### DIFF
--- a/src/iFrame/iFrame.csproj
+++ b/src/iFrame/iFrame.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="System.Text.Json" Version="9.0.9" />
 	<PackageReference Include="BlazorWasmPreRendering.Build" Version="6.0.0" />
-	<PackageReference Include="PublishSPAforGitHubPages.Build" Version="3.0.1" />
+	<PackageReference Include="PublishSPAforGitHubPages.Build" Version="3.0.3" />
 	<PackageReference Include="ValueOf" Version="2.0.31" />
   </ItemGroup>
 


### PR DESCRIPTION
Bumps PublishSPAforGitHubPages.Build from 3.0.1 to 3.0.3

---
updated-dependencies:
- dependency-name: PublishSPAforGitHubPages.Build dependency-version: 3.0.3 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: open-source-license ...